### PR TITLE
Added Payable Key word in the  Interaction.s.sol 

### DIFF
--- a/script/Interactions.s.sol
+++ b/script/Interactions.s.sol
@@ -11,7 +11,7 @@ contract FundFundMe is Script {
 
     function fundFundMe(address mostRecentlyDeployed) public {
         vm.startBroadcast();
-        FundMe(mostRecentlyDeployed).fund{value: SEND_VALUE}();
+        FundMe(payable(mostRecentlyDeployed)).fund{value: SEND_VALUE}();
         vm.stopBroadcast();
         console.log("Funded FundMe with %s", SEND_VALUE);
     }
@@ -28,7 +28,7 @@ contract FundFundMe is Script {
 contract WithdrawFundMe is Script {
     function withdrawFundMe(address mostRecentlyDeployed) public {
         vm.startBroadcast();
-        FundMe(mostRecentlyDeployed).withdraw();
+        FundMe(payable(mostRecentlyDeployed)).withdraw();
         vm.stopBroadcast();
         console.log("Withdraw FundMe balance!");
     }


### PR DESCRIPTION
While running the Interaction.s.sol Script, It pops out the Error in both the function:-
 1. In fundFundMe and WithdrawFundMe Functions ERROR Says -
   ```Explicit type conversion not allowed from non-payable "address" to "contract FundMe", which has a payable fallback function.```

After Adding Payable To the Respective Lines It solves the error
Line 1 - ```FundMe(payable(mostRecentlyDeployed)).fund{value: SEND_VALUE}();```
Line 2 - ``` FundMe(payable(mostRecentlyDeployed)).withdraw();```