### PR TITLE
hoax inside testWithDrawFromMultipleFunders function of unit-test file updated

### DIFF
--- a/test/unit/FundMeTest.t.sol
+++ b/test/unit/FundMeTest.t.sol
@@ -108,7 +108,7 @@ contract FundMeTest is StdCheats, Test {
         ) {
             // we get hoax from stdcheats
             // prank + deal
-            hoax(address(i), SEND_VALUE);
+            hoax(address(i), STARTING_USER_BALANCE);
             fundMe.fund{value: SEND_VALUE}();
         }
 


### PR DESCRIPTION
I think in `FundMeTest.t.sol` file, inside `testWithDrawFromMultipleFunders()` function, while assigning 'hoax', the value of the initial amount would be accurate if we use STARTING_USER_BALANCE. Line: 111

Previously:
![image](https://github.com/Cyfrin/foundry-fund-me-f23/assets/98945276/2f6e079b-6d8b-4f43-8d6d-1bce5a60890f)
 
What I suggest:
![image](https://github.com/Cyfrin/foundry-fund-me-f23/assets/98945276/6dcb2334-9fbd-4f8a-b803-25f0dbbece0f)
