### PR TITLE
Removed unneeded import from Interactions.s.sol

### DIFF
--- a/script/Interactions.s.sol
+++ b/script/Interactions.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import {Script, console} from "forge-std/Script.sol";
-import {HelperConfig} from "./HelperConfig.s.sol";
 import {FundMe} from "../src/FundMe.sol";
 import {DevOpsTools} from "foundry-devops/src/DevOpsTools.sol";
 


### PR DESCRIPTION
Hey! The `HelperConfig` import looked like it was not needed in `Interactions.s.sol` so I removed it. Please correct me if I am wrong.