### PR TITLE
refactor: remove unused import for HelperConfig from DeployFunWithStorage

### DIFF
--- a/script/DeployStorageFun.s.sol
+++ b/script/DeployStorageFun.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import {Script, console} from "forge-std/Script.sol";
-import {HelperConfig} from "./HelperConfig.s.sol";
 import {FunWithStorage} from "../src/exampleContracts/FunWithStorage.sol";
 
 contract DeployFunWithStorage is Script {
@@ -18,7 +17,7 @@ contract DeployFunWithStorage is Script {
     function printStorageData(address contractAddress) public view {
         for (uint256 i = 0; i < 10; i++) {
             bytes32 value = vm.load(contractAddress, bytes32(i));
-            console.log("Vale at location", i, ":");
+            console.log("Vaule at location", i, ":");
             console.logBytes32(value);
         }
     }


### PR DESCRIPTION
Title: refactor: remove unused import for HelperConfig from DeployFunWithStorage

Description: The contract has unused import of `HelperConfig.sol`. 

Changes Made:
- Removed unused import.
- fixed a minor typo in `console.log` 

Testing: The change has been tested locally and confirmed to `DeployFunWithStorage` is working as expected.