### PR TITLE
Update Import for  AggregatorV3Interface

### DIFF
--- a/src/FundMe.sol
+++ b/src/FundMe.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.19;
 // 2. Imports
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import {PriceConverter} from "./PriceConverter.sol";
 
 // 3. Interfaces, Libraries, Contracts

--- a/src/PriceConverter.sol
+++ b/src/PriceConverter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 
 library PriceConverter {
     function getPrice(AggregatorV3Interface priceFeed) internal view returns (uint256) {


### PR DESCRIPTION
Not 100% sure if this will work correctly, as I am not familiar with how the remapping works here, but I found out that the path to the `AggregatorV3Interface` has changed. Please [verify this here](https://github.com/smartcontractkit/chainlink/tree/develop/contracts/src/v0.8/shared/interfaces)
