### PR TITLE
Refactor import path for AggregatorV3Interface

### DIFF
--- a/src/PriceConverter.sol
+++ b/src/PriceConverter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "@chainlink/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 library PriceConverter {
     function getPrice(AggregatorV3Interface priceFeed) internal view returns (uint256) {


### PR DESCRIPTION
Updates the import path for the AggregatorV3Interface

https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol