### PR TITLE
Updates foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,13 +4,13 @@ out = 'out'
 libs = ['lib']
 remappings = ['@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/']
 ffi = true
+fs_permissions = [{ access = "read", path = "./broadcast" }]
 
 [etherscan]
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
-sepolia = {key = "${ETHERSCAN_API_KEY}"}
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
 
 [rpc_endpoints]
 sepolia = "${SEPOLIA_RPC_URL}"
 
-fs_permissions = [{ access = "read", path = "./broadcast" }]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Currently, if we try to build the project the execution will halt with the following error:
```
Error: 
failed to extract foundry config:
foundry config error: invalid type: found sequence, expected a string for setting `rpc_endpoints.fs_permissions`
```

This error is thrown because the `fs_permissions` option is under the `rpc_endpoints` profile. Foundry will assume there is a RPC url with a `fs_permissions` name and the url is the array, since `string` is the expected type for the RPC url the build fails.

To solve this problem I moved the option to be under the default profile.

Also I added bracket spacing to the sepolia etherscan endpoint for style consistency.