### PR TITLE
chore: set correct Patrick Collins Medium URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ ETH/Arbitrum/Optimism/Polygon/etc Address: 0x9680201d9c93d65a3603d2088d125e955c7
 [![Patrick Collins Twitter](https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white)](https://twitter.com/PatrickAlphaC)
 [![Patrick Collins YouTube](https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/channel/UCn-3f8tw_E1jZvhuHatROwA)
 [![Patrick Collins Linkedin](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/patrickalphac/)
-[![Patrick Collins Medium](https://img.shields.io/badge/Medium-000000?style=for-the-badge&logo=medium&logoColor=white)](https://medium.com/@patrick.collins_58673/)
+[![Patrick Collins Medium](https://img.shields.io/badge/Medium-000000?style=for-the-badge&logo=medium&logoColor=white)](https://patrickalphac.medium.com/)
 
 <!-- Testing krunchdata https://kdta.io/b6T40  -->


### PR DESCRIPTION
## Description

Unless you tell me Patrick is secretly a food influencer, I'd say the Medium badge doesn't link to the profile of the Patrick Collins we all know! :open_mouth:

This PR sets the correct @PatrickAlphaC Medium account URL in the "Patrick Collins Medium" badge.