### PR TITLE
Updated command for deploying Interactions.s.sol contract 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,11 @@ endif
 deploy:
 	@forge script script/DeployFundMe.s.sol:DeployFundMe $(NETWORK_ARGS)
 
+// For deploying Interactions.s.sol:FundFundMe as well as for Interactions.s.sol:WithdrawFundMe we have to include a sender's address `--sender <ADDRESS>`
+SENDER_ADDRESS := <sender's address> 
+
 fund:
-	@forge script script/Interactions.s.sol:FundFundMe $(NETWORK_ARGS)
+	@forge script script/Interactions.s.sol:FundFundMe --sender $(SENDER_ADDRESS) $(NETWORK_ARGS)
 
 withdraw:
-	@forge script script/Interactions.s.sol:WithdrawFundMe $(NETWORK_ARGS)
+	@forge script script/Interactions.s.sol:WithdrawFundMe --sender $(SENDER_ADDRESS) $(NETWORK_ARGS)


### PR DESCRIPTION
While deploying the Interactions.s.sol contract we have to include the `--sender <ADDRESS>` sender's address in the forge script command otherwise it will throw an error.