### PR TITLE
Refactor ”testUserCanFundAndOwnerWithdraw“ for Enhanced Clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a section of the Cyfrin Solidity Course.
   - [Quickstart](#quickstart)
     - [Optional Gitpod](#optional-gitpod)
 - [Usage](#usage)
-  - [Deploy:](#deploy)
+  - [Deploy](#deploy)
   - [Testing](#testing)
     - [Test Coverage](#test-coverage)
 - [Deployment to a testnet or mainnet](#deployment-to-a-testnet-or-mainnet)
@@ -47,7 +47,7 @@ If you can't or don't want to run and install locally, you can work with this re
 
 # Usage
 
-## Deploy:
+## Deploy
 
 ```
 forge script script/DeployFundMe.s.sol

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a section of the Cyfrin Solidity Course.
   - [Quickstart](#quickstart)
     - [Optional Gitpod](#optional-gitpod)
 - [Usage](#usage)
+  - [Deploy:](#deploy)
   - [Testing](#testing)
     - [Test Coverage](#test-coverage)
 - [Deployment to a testnet or mainnet](#deployment-to-a-testnet-or-mainnet)
@@ -103,7 +104,7 @@ You'll want to set your `SEPOLIA_RPC_URL` and `PRIVATE_KEY` as environment varia
 
 Optionally, add your `ETHERSCAN_API_KEY` if you want to verify your contract on [Etherscan](https://etherscan.io/).
 
-1. Get testnet ETH
+2. Get testnet ETH
 
 Head over to [faucets.chain.link](https://faucets.chain.link/) and get some testnet ETH. You should see the ETH show up in your metamask.
 

--- a/test/integration/InteractionsTest.t.sol
+++ b/test/integration/InteractionsTest.t.sol
@@ -30,12 +30,21 @@ contract InteractionsTest is StdCheats, Test {
     }
 
     function testUserCanFundAndOwnerWithdraw() public {
-        FundFundMe fundFundMe = new FundFundMe();
-        fundFundMe.fundFundMe(address(fundMe));
+        uint256 preUserBalance = address(USER).balance;
+        uint256 preOwnerBalance = address(fundMe.getOwner()).balance;
+
+        // Using vm.prank to simulate funding from the USER address
+        vm.prank(USER);
+        fundMe.fund{value: SEND_VALUE}();
 
         WithdrawFundMe withdrawFundMe = new WithdrawFundMe();
         withdrawFundMe.withdrawFundMe(address(fundMe));
 
+        uint256 afterUserBalance = address(USER).balance;
+        uint256 afterOwnerBalance = address(fundMe.getOwner()).balance;
+
         assert(address(fundMe).balance == 0);
+        assertEq(afterUserBalance + SEND_VALUE, preUserBalance);
+        assertEq(preOwnerBalance + SEND_VALUE, afterOwnerBalance);
     }
 }


### PR DESCRIPTION
### Proposed Changes:
This PR addresses the issue raised in [#69] where the `testUserCanFundAndOwnerWithdraw` function implied that a user represented by `address(1)` funded the `FundMe` contract. However, the actual funder was the default Foundry account. To resolve this and improve code readability. 

This PR further refines the `testUserCanFundAndOwnerWithdraw` function to not only simulate funding from the `USER` address but also to ensure the correctness of balance changes for both the user and the contract owner. The following updates have been made:

- The test function now explicitly uses `vm.prank(USER)` to simulate the funding transaction from the `USER` address.
- Added explanatory comments to clarify why `vm.prank(USER)` is used.
- Added new assertions to verify the user's balance is deducted correctly and the owner's balance is incremented post-funding and withdrawal.

### Why These Changes:
This change makes the test more intuitive and aligns the test's narrative with the actual actions being performed. It ensures that the test name `testUserCanFundAndOwnerWithdraw` accurately reflects the test's operations.

The additional assertions serve to reinforce the reliability of the test. They validate that the `FundMe` contract behaves as expected when interacting with user funds and when the owner withdraws. This ensures that:

- The user's balance decreases by the `SEND_VALUE` after funding.
- The owner's balance increases by the `SEND_VALUE` after withdrawal.

These checks are essential for maintaining contract integrity and trust from the users' perspective.

Resolves [#69]



